### PR TITLE
Fix command not found message

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
   },
   "repository": "tiagonapoli/oclif-plugin-spaced-commands",
   "scripts": {
-    "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json",
+    "postpack": "rm -f oclif.manifest.json",
     "posttest": "tsc -p test --noEmit && tslint -p test -t stylish",
-    "prepack": "rm -rf lib && tsc && oclif-dev manifest && oclif-dev readme && npm shrinkwrap",
+    "prepack": "rm -rf lib && tsc && oclif-dev manifest && oclif-dev readme",
     "prepare": "rm -rf lib && tsc",
     "test": "nyc mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif-dev readme && git add README.md"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "files": [
     "/lib",
-    "/npm-shrinkwrap.json",
     "/oclif.manifest.json",
     "/yarn.lock"
   ],
@@ -48,9 +47,7 @@
   "oclif": {
     "commands": "./lib/commands",
     "bin": "oclif-example",
-    "devPlugins": [
-      "@oclif/plugin-help"
-    ],
+    "devPlugins": [],
     "hooks": {
       "init": [
         "./lib/hooks/init"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tiagonapoli/oclif-plugin-spaced-commands",
   "description": "convert an oclif CLI to use spaced commands",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Philipe Navarro @RasPhilCo Tiago Nápoli @tiagonapoli",
   "bugs": "https://github.com/tiagonapoli/oclif-plugin-spaced-commands",
   "dependencies": {
@@ -36,8 +36,7 @@
   },
   "files": [
     "/lib",
-    "/oclif.manifest.json",
-    "/yarn.lock"
+    "/oclif.manifest.json"
   ],
   "homepage": "https://github.com/tiagonapoli/oclif-plugin-spaced-commands",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@oclif/plugin-spaced-commands",
+  "name": "@tiagonapoli/oclif-plugin-spaced-commands",
   "description": "convert an oclif CLI to use spaced commands",
-  "version": "0.0.0",
-  "author": "Philipe Navarro @RasPhilCo",
-  "bugs": "https://github.com/RasPhilCo/oclif-plugin-spaced-commands/issues",
+  "version": "0.0.1",
+  "author": "Philipe Navarro @RasPhilCo Tiago Nápoli @tiagonapoli",
+  "bugs": "https://github.com/tiagonapoli/oclif-plugin-spaced-commands",
   "dependencies": {
     "@oclif/command": "^1",
     "@oclif/config": "^1",
@@ -40,7 +40,7 @@
     "/oclif.manifest.json",
     "/yarn.lock"
   ],
-  "homepage": "https://github.com/RasPhilCo/oclif-plugin-spaced-commands",
+  "homepage": "https://github.com/tiagonapoli/oclif-plugin-spaced-commands",
   "keywords": [
     "oclif-plugin"
   ],
@@ -57,7 +57,7 @@
       ]
     }
   },
-  "repository": "RasPhilCo/spaces",
+  "repository": "tiagonapoli/oclif-plugin-spaced-commands",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json",
     "posttest": "tsc -p test --noEmit && tslint -p test -t stylish",

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -3,6 +3,8 @@ import {CLIError} from '@oclif/errors'
 
 import CommandTree from '../tree'
 
+const CommandHelp = require('@oclif/plugin-help/lib/command').default
+
 // deps in Help#topics
 const stripAnsi = require('strip-ansi').stripAnsi
 const {compact} = require('@oclif/plugin-help/lib/util')
@@ -54,6 +56,16 @@ export const init: Config.Hook<'init'> = async function (ctx) {
     return
   }
   ctx.config.findCommand = spacesFindCommand
+
+  //overwrite commandHelp.defaultUsage
+  CommandHelp.prototype.defaultUsage = function(_: Config.Command.Flag[]): string {
+    return compact([
+      this.command.id.replace(':', ' '),
+      this.command.args.filter((a: any) => !a.hidden).map((a: any) => this.arg(a)).join(' '),
+      // flags.length && '[OPTIONS]',
+    ]).join(' ')
+  }
+  
 
   // overwrite config.findTopic
   const findTopic = ctx.config.findTopic

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -65,7 +65,7 @@ export const init: Config.Hook<'init'> = async function (ctx) {
       // flags.length && '[OPTIONS]',
     ]).join(' ')
   }
-  
+
 
   // overwrite config.findTopic
   const findTopic = ctx.config.findTopic
@@ -81,6 +81,7 @@ export const init: Config.Hook<'init'> = async function (ctx) {
 
   // overwrite config.runCommand
   ctx.config.runCommand = async (id: string, argv: string[] = []) => {
+    const originalId = id
     // tslint:disable-next-line:no-unused
     let [_, name] = tree.findMostProgressiveCmd(RAWARGV)
     // override the id b/c of the closure
@@ -90,7 +91,7 @@ export const init: Config.Hook<'init'> = async function (ctx) {
     const c = ctx.config.findCommand('')
     if (!c) {
       await ctx.config.runHook('command_not_found', {id})
-      throw new CLIError(`command ${id} not found`)
+      throw new CLIError(`command ${originalId} not found`)
     }
     const command = c.load()
     await ctx.config.runHook('prerun', {Command: command, argv})


### PR DESCRIPTION
Before, the id of the command was only a space so the message was `Error: command  not found` instead of `Error: command list not found`, for list for example.